### PR TITLE
Add support for GigaAM v3 model

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -294,6 +294,38 @@
             </intent-filter>
         </activity-alias>
 
+        <activity-alias
+            android:name=".ShareGigaam"
+            android:targetActivity=".receiver.ShareReceiverActivity"
+            android:enabled="false"
+            android:exported="true"
+            android:label="@string/share_target_gigaam"
+            android:excludeFromRecents="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/ogg" />
+            </intent-filter>
+            <!-- Video files: audio container only (audio track extracted, no visual analysis). -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/mp4" />
+            </intent-filter>
+        </activity-alias>
+
         <!-- Transparent trampoline for Tasker: brings app to foreground so InferenceService
              can be started legally on Android 12+. Finishes immediately, never visible. -->
         <activity

--- a/app/src/main/java/com/antivocale/app/data/PreferencesManager.kt
+++ b/app/src/main/java/com/antivocale/app/data/PreferencesManager.kt
@@ -12,6 +12,7 @@ interface PreferencesManager {
     val whisperModelPath: Flow<String?>
     val qwen3AsrModelPath: Flow<String?>
     val nemotronModelPath: Flow<String?>
+    val gigaamModelPath: Flow<String?>
     val ggufModelPath: Flow<String?>
     val autoCopyEnabled: Flow<Boolean>
     val outputFolderUri: Flow<String?>
@@ -41,6 +42,9 @@ interface PreferencesManager {
 
     suspend fun saveNemotronModelPath(path: String)
     suspend fun clearNemotronModelPath()
+
+    suspend fun saveGigaAmModelPath(path: String)
+    suspend fun clearGigaAmModelPath()
 
     suspend fun saveGgufModelPath(path: String)
     suspend fun clearGgufModelPath()

--- a/app/src/main/java/com/antivocale/app/data/PreferencesManagerImpl.kt
+++ b/app/src/main/java/com/antivocale/app/data/PreferencesManagerImpl.kt
@@ -33,6 +33,7 @@ class PreferencesManagerImpl(
         private val WHISPER_MODEL_PATH = stringPreferencesKey("whisper_model_path")
         private val QWEN3_ASR_MODEL_PATH = stringPreferencesKey("qwen3_asr_model_path")
         private val NEMOTRON_MODEL_PATH = stringPreferencesKey("nemotron_model_path")
+        private val GIGAAM_MODEL_PATH = stringPreferencesKey("gigaam_model_path")
         private val GGUF_MODEL_PATH = stringPreferencesKey("gguf_model_path")
         private val AUTO_COPY_ENABLED = booleanPreferencesKey("auto_copy_enabled")
         private val OUTPUT_FOLDER_URI = stringPreferencesKey("output_folder_uri")
@@ -63,6 +64,7 @@ class PreferencesManagerImpl(
         val whisperModelPath: String? = null,
         val qwen3AsrModelPath: String? = null,
         val nemotronModelPath: String? = null,
+        val gigaamModelPath: String? = null,
         val ggufModelPath: String? = null,
         val autoCopyEnabled: Boolean = PreferencesManager.DEFAULT_AUTO_COPY_ENABLED,
         val outputFolderUri: String? = null,
@@ -90,6 +92,7 @@ class PreferencesManagerImpl(
         whisperModelPath = this[WHISPER_MODEL_PATH],
         qwen3AsrModelPath = this[QWEN3_ASR_MODEL_PATH],
         nemotronModelPath = this[NEMOTRON_MODEL_PATH],
+        gigaamModelPath = this[GIGAAM_MODEL_PATH],
         ggufModelPath = this[GGUF_MODEL_PATH],
         autoCopyEnabled = this[AUTO_COPY_ENABLED] ?: PreferencesManager.DEFAULT_AUTO_COPY_ENABLED,
         outputFolderUri = this[OUTPUT_FOLDER_URI],
@@ -237,6 +240,23 @@ class PreferencesManagerImpl(
 
     override val ggufModelPath: Flow<String?> = context.dataStore.data.map { it[GGUF_MODEL_PATH] }
         .onStart { emit(cache.get().ggufModelPath) }
+
+    override val gigaamModelPath: Flow<String?> = context.dataStore.data.map { it[GIGAAM_MODEL_PATH] }
+        .onStart { emit(cache.get().gigaamModelPath) }
+
+    override suspend fun saveGigaAmModelPath(path: String) {
+        context.dataStore.edit { preferences ->
+            preferences[GIGAAM_MODEL_PATH] = path
+        }
+        cache.updateAndGet { it.copy(gigaamModelPath = path) }
+    }
+
+    override suspend fun clearGigaAmModelPath() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(GIGAAM_MODEL_PATH)
+        }
+        cache.updateAndGet { it.copy(gigaamModelPath = null) }
+    }
 
     override suspend fun saveGgufModelPath(path: String) {
         context.dataStore.edit { preferences ->

--- a/app/src/main/java/com/antivocale/app/data/ShareTargetManager.kt
+++ b/app/src/main/java/com/antivocale/app/data/ShareTargetManager.kt
@@ -4,6 +4,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
+import com.antivocale.app.transcription.GigaAmBackend
 import com.antivocale.app.transcription.LlmTranscriptionBackend
 import com.antivocale.app.transcription.Qwen3AsrBackend
 import com.antivocale.app.transcription.SherpaOnnxBackend
@@ -29,7 +30,8 @@ class ShareTargetManager(
             ShareTarget("com.antivocale.app.ShareWhisper", WhisperBackend.BACKEND_ID),
             ShareTarget("com.antivocale.app.ShareQwen3", Qwen3AsrBackend.BACKEND_ID),
             ShareTarget("com.antivocale.app.ShareGemma", LlmTranscriptionBackend.BACKEND_ID),
-            ShareTarget("com.antivocale.app.ShareNemotron", NemotronStreamingBackend.BACKEND_ID)
+            ShareTarget("com.antivocale.app.ShareNemotron", NemotronStreamingBackend.BACKEND_ID),
+            ShareTarget("com.antivocale.app.ShareGigaam", GigaAmBackend.BACKEND_ID)
         )
     }
 
@@ -40,6 +42,7 @@ class ShareTargetManager(
             Qwen3AsrBackend.BACKEND_ID -> preferencesManager.qwen3AsrModelPath.first() != null
             LlmTranscriptionBackend.BACKEND_ID -> preferencesManager.modelPath.first() != null
             NemotronStreamingBackend.BACKEND_ID -> preferencesManager.nemotronModelPath.first() != null
+            GigaAmBackend.BACKEND_ID -> preferencesManager.gigaamModelPath.first() != null
             else -> false
         }
     }

--- a/app/src/main/java/com/antivocale/app/data/download/SherpaOnnxModelDownloader.kt
+++ b/app/src/main/java/com/antivocale/app/data/download/SherpaOnnxModelDownloader.kt
@@ -167,8 +167,11 @@ class SherpaOnnxModelDownloader<V>(
 
                             Log.i(config.tag, "Downloading: $fileName")
 
+                            val url = config.urlBuilder?.invoke(variant, fileName)
+                                ?: hfFileUrl(config.hfRepoNames[variant] ?: "pantinor/$modelDirName", fileName)
+
                             val downloadConfig = DownloadConfig(
-                                url = hfFileUrl(config.hfRepoNames[variant] ?: "pantinor/$modelDirName", fileName),
+                                url = url,
                                 tempFile = targetFile,
                                 targetFile = targetFile,
                                 estimatedSizeBytes = 0L,
@@ -317,5 +320,11 @@ data class SherpaOnnxModelConfig<V>(
     val ensureParentDirs: Boolean = false,
     val expectedSha256: Map<V, Map<String, String>> = emptyMap(),
     /** Full "owner/repo" overrides for variants that don't live under the default "pantinor/" namespace. */
-    val hfRepoNames: Map<V, String> = emptyMap()
+    val hfRepoNames: Map<V, String> = emptyMap(),
+    /**
+     * Optional per-variant URL builder for models NOT hosted on HuggingFace (e.g. GitHub
+     * release assets). When non-null it takes precedence over the HuggingFace URL derived
+     * from [hfRepoNames] / [hfFileNames].
+     */
+    val urlBuilder: ((variant: V, fileName: String) -> String)? = null
 )

--- a/app/src/main/java/com/antivocale/app/di/TranscriptionModule.kt
+++ b/app/src/main/java/com/antivocale/app/di/TranscriptionModule.kt
@@ -1,6 +1,7 @@
 package com.antivocale.app.di
 
 import com.antivocale.app.manager.LlmManager
+import com.antivocale.app.transcription.GigaAmBackend
 import com.antivocale.app.transcription.LlmTranscriptionBackend
 import com.antivocale.app.transcription.NemotronStreamingBackend
 import com.antivocale.app.transcription.Qwen3AsrBackend
@@ -39,6 +40,11 @@ class TranscriptionModule {
         @IntoSet
         @Singleton
         fun provideQwen3AsrBackend(): TranscriptionBackend = Qwen3AsrBackend()
+
+        @Provides
+        @IntoSet
+        @Singleton
+        fun provideGigaAmBackend(): TranscriptionBackend = GigaAmBackend()
 
         @Provides
         @IntoSet

--- a/app/src/main/java/com/antivocale/app/receiver/ShareReceiverActivity.kt
+++ b/app/src/main/java/com/antivocale/app/receiver/ShareReceiverActivity.kt
@@ -22,6 +22,7 @@ import com.antivocale.app.R
 import com.antivocale.app.data.PreferencesManager
 import com.antivocale.app.receiver.ChooserBroadcastReceiver
 import com.antivocale.app.service.InferenceService
+import com.antivocale.app.transcription.GigaAmBackend
 import com.antivocale.app.transcription.LlmTranscriptionBackend
 import com.antivocale.app.transcription.Qwen3AsrBackend
 import com.antivocale.app.transcription.SherpaOnnxBackend
@@ -79,6 +80,7 @@ class ShareReceiverActivity : Activity() {
         private const val ALIAS_QWEN3 = "com.antivocale.app.ShareQwen3"
         private const val ALIAS_GEMMA = "com.antivocale.app.ShareGemma"
         private const val ALIAS_NEMOTRON = "com.antivocale.app.ShareNemotron"
+        private const val ALIAS_GIGAAM = "com.antivocale.app.ShareGigaam"
 
         // The choice prompt auto-resolves to ASR after this delay if the user does nothing.
         // Keeps a shared video from silently hanging when the notification is ignored.
@@ -95,6 +97,7 @@ class ShareReceiverActivity : Activity() {
             ALIAS_QWEN3 -> Qwen3AsrBackend.BACKEND_ID
             ALIAS_GEMMA -> LlmTranscriptionBackend.BACKEND_ID
             ALIAS_NEMOTRON -> NemotronStreamingBackend.BACKEND_ID
+            ALIAS_GIGAAM -> GigaAmBackend.BACKEND_ID
             else -> null
         }
     }

--- a/app/src/main/java/com/antivocale/app/service/ExtractionService.kt
+++ b/app/src/main/java/com/antivocale/app/service/ExtractionService.kt
@@ -12,6 +12,7 @@ import com.antivocale.app.R
 import com.antivocale.app.data.ModelDownloader
 import com.antivocale.app.data.download.DownloadState
 import com.antivocale.app.data.HuggingFaceTokenManager
+import com.antivocale.app.transcription.GigaAmDownloader
 import com.antivocale.app.transcription.NemotronDownloader
 import com.antivocale.app.transcription.ParakeetDownloader
 import com.antivocale.app.transcription.Qwen3AsrDownloader
@@ -77,6 +78,7 @@ class ExtractionService : Service() {
         WHISPER("whisper"),
         QWEN3_ASR("qwen3-asr"),
         NEMOTRON("nemotron"),
+        GIGAAM("gigaam"),
         GEMMA("gemma"),
         GEMMA4_GGUF("gemma4-gguf");
 
@@ -126,6 +128,7 @@ class ExtractionService : Service() {
                 qv?.let { getString(it.titleResId) } ?: "Qwen3-ASR"
             }
             ModelType.NEMOTRON -> getString(R.string.nemotron_name)
+            ModelType.GIGAAM -> getString(R.string.gigaam_name)
             ModelType.GEMMA -> GemmaVariant.fromString(variant).displayName
             // GGUF: disabled
             // ModelType.GEMMA4_GGUF -> { val gv = GgufVariant.fromString(variant); gv?.let { getString(it.titleResId) } ?: "Gemma 4 GGUF" }
@@ -278,6 +281,16 @@ class ExtractionService : Service() {
                         }
                     )
                 }
+                ModelType.GIGAAM -> {
+                    GigaAmDownloader.downloadModel(
+                        context = applicationContext,
+                        onProgress = {},
+                        onStateChange = { state ->
+                            _progressState.tryEmit(ExtractionProgress(ModelType.GIGAAM, variant, downloadState = state))
+                            updateNotificationFromState(key, state)
+                        }
+                    )
+                }
                 ModelType.GEMMA -> {
                     val gemmaVariant = GemmaVariant.fromString(variant)
                     ModelDownloader.downloadModel(
@@ -366,6 +379,9 @@ class ExtractionService : Service() {
             }
             ModelType.NEMOTRON -> {
                 NemotronDownloader.cancel()
+            }
+            ModelType.GIGAAM -> {
+                GigaAmDownloader.cancel()
             }
             // GGUF: disabled
             ModelType.GEMMA4_GGUF -> { /* no-op: GGUF downloader not available */ }

--- a/app/src/main/java/com/antivocale/app/transcription/GigaAmBackend.kt
+++ b/app/src/main/java/com/antivocale/app/transcription/GigaAmBackend.kt
@@ -1,0 +1,192 @@
+package com.antivocale.app.transcription
+
+import android.content.Context
+import android.util.Log
+import com.k2fsa.sherpa.onnx.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Transcription backend using sherpa-onnx with the GigaAM v3 E2E RNNT (nemo_transducer).
+ *
+ * GigaAM is an end-to-end Russian ASR model from Sber (MIT) with native punctuation and
+ * capitalization. It is the strongest on-device choice for Russian — the ONNX files
+ * ship as GitHub release assets (see [GigaAmDownloader]).
+ *
+ * Architecture: nemo_transducer, exactly the same shape as Parakeet TDT, so it reuses the
+ * sherpa `OfflineTransducerModelConfig` with GigaAM's own encoder/decoder/joiner/tokens.
+ */
+@Singleton
+class GigaAmBackend @Inject constructor() : TranscriptionBackend {
+
+    companion object {
+        const val BACKEND_ID = "gigaam"
+        private const val TAG = "GigaAmBackend"
+    }
+
+    override val id: String = BACKEND_ID
+    override val displayName: String = "GigaAM v3 (Russian)"
+    override val supportsAudio: Boolean = true
+    override val supportsText: Boolean = false  // ASR-only, no text generation
+
+    // GigaAM handles long audio in a single pass - no chunking needed.
+    override val maxChunkDurationSeconds: Int? = null
+
+    private var recognizer: OfflineRecognizer? = null
+    private var modelDir: String? = null
+    private var isInitialized = false
+
+    override suspend fun initialize(context: Context, config: BackendConfig): Result<Unit> {
+        val sherpaConfig = config as? BackendConfig.SherpaOnnxConfig
+            ?: return Result.failure(IllegalArgumentException("Invalid config type for GigaAmBackend"))
+
+        if (isInitialized) {
+            Log.w(TAG, "Already initialized, returning success")
+            return Result.success(Unit)
+        }
+
+        val modelDirectory = sherpaConfig.modelDir
+        Log.i(TAG, "Initializing GigaAM with model dir: $modelDirectory")
+
+        val dir = File(modelDirectory)
+        if (!dir.exists() || !dir.isDirectory) {
+            return Result.failure(TranscriptionException.ModelLoadError("directory not found: $modelDirectory"))
+        }
+
+        val model = GigaAmModelManager.validateModelDirectory(dir)
+        if (model == null) {
+            return Result.failure(TranscriptionException.ModelLoadError(
+                "missing files in $modelDirectory: ${GigaAmModelManager.REQUIRED_FILES.joinToString()}"
+            ))
+        }
+
+        // Pre-native validation (inside IO dispatcher): sherpa-onnx calls exit(255)
+        // when the encoder is missing critical metadata, killing the app silently.
+        val encoderFile = File(dir, "gigaam_v3_e2e_rnnt_encoder_int8.onnx")
+        val missingMeta = SherpaOnnxBackend.missingOnnxMetadata(encoderFile, listOf("vocab_size", "subsampling_factor", "model_type"))
+        if (missingMeta.isNotEmpty()) {
+            Log.e(TAG, "Encoder missing required ONNX metadata: $missingMeta")
+            return Result.failure(TranscriptionException.ModelLoadError(
+                "model file is missing required metadata ($missingMeta). " +
+                    "The model may be corrupt or an incompatible export. Try re-downloading it."
+            ))
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                Log.i(TAG, "Creating OfflineRecognizer config for GigaAM...")
+
+                // Configure the transducer model (GigaAM v3 E2E RNNT uses nemo_transducer)
+                val modelConfig = OfflineModelConfig(
+                    transducer = OfflineTransducerModelConfig(
+                        encoder = "${modelDirectory}/gigaam_v3_e2e_rnnt_encoder_int8.onnx",
+                        decoder = "${modelDirectory}/gigaam_v3_e2e_rnnt_decoder.onnx",
+                        joiner = "${modelDirectory}/gigaam_v3_e2e_rnnt_joint.onnx"
+                    ),
+                    tokens = "${modelDirectory}/gigaam_v3_e2e_rnnt_tokens.txt",
+                    modelType = "nemo_transducer",
+                    numThreads = sherpaConfig.numThreads,
+                    debug = false,
+                    provider = sherpaConfig.provider
+                )
+
+                val recognizerConfig = OfflineRecognizerConfig(
+                    modelConfig = modelConfig,
+                    featConfig = FeatureConfig(
+                        sampleRate = 16000,
+                        featureDim = 80
+                    ),
+                    decodingMethod = "greedy_search"
+                )
+
+                Log.i(TAG, "Creating OfflineRecognizer...")
+                recognizer = OfflineRecognizer(config = recognizerConfig)
+
+                modelDir = modelDirectory
+                isInitialized = true
+
+                Log.i(TAG, "GigaAM backend initialized successfully")
+                Result.success(Unit)
+
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to initialize GigaAM", e)
+                Result.failure(TranscriptionException.ModelLoadError(e.message ?: "unknown", e))
+            } catch (e: Error) {
+                // Catch native errors (UnsatisfiedLinkError, etc.)
+                Log.e(TAG, "Native error initializing GigaAM", e)
+                Result.failure(TranscriptionException.NativeError(e.message ?: "unknown", e))
+            }
+        }
+    }
+
+    override suspend fun transcribeAudio(samples: FloatArray, sampleRate: Int, prompt: String): Result<TranscriptionResult> {
+        val rec = recognizer
+            ?: return Result.failure(TranscriptionException.NotInitialized())
+
+        return withContext(Dispatchers.IO) {
+            try {
+                Log.d(TAG, "Transcribing audio: ${samples.size} samples at ${sampleRate}Hz")
+
+                // Append 1s of silence to improve final token accuracy (same as Parakeet).
+                val silencePad = FloatArray(sampleRate)
+                val padded = samples + silencePad
+
+                val stream = rec.createStream()
+                stream.acceptWaveform(padded, sampleRate)
+                rec.decode(stream)
+
+                val result = rec.getResult(stream)
+                val transcription = result.text
+                val detectedLang = result.lang.ifBlank { null }
+
+                stream.release()
+
+                Log.d(TAG, "Transcription complete: '${transcription.take(100)}...' (${transcription.length} chars)")
+
+                if (transcription.isBlank()) {
+                    Result.failure(TranscriptionException.NoTranscriptionProduced())
+                } else {
+                    val confidence = TranscriptionResult.computeConfidence(transcription, padded.size, sampleRate)
+                    Result.success(TranscriptionResult(
+                        text = transcription,
+                        confidence = confidence,
+                        detectedLanguage = detectedLang
+                    ))
+                }
+
+            } catch (e: Exception) {
+                Log.e(TAG, "Transcription failed", e)
+                Result.failure(TranscriptionException.NativeError(e.message ?: "unknown", e))
+            }
+        }
+    }
+
+    override suspend fun generateText(prompt: String): Result<String> {
+        // sherpa-onnx is ASR-only, no text generation support
+        return Result.failure(UnsupportedOperationException(
+            "Text generation not supported by GigaAM backend. Use for audio transcription only."
+        ))
+    }
+
+    override fun isReady(): Boolean = isInitialized && recognizer != null
+
+    override fun isAudioSupported(): Boolean = true
+
+    override fun unload() {
+        Log.i(TAG, "Unloading GigaAM backend")
+        recognizer?.release()
+        recognizer = null
+        modelDir = null
+        isInitialized = false
+    }
+
+    override fun setKeepAliveTimeout(minutes: Int) {
+        // No-op: GigaAM backend doesn't manage its own lifecycle
+    }
+
+    override fun getModelPath(): String? = modelDir
+
+}

--- a/app/src/main/java/com/antivocale/app/transcription/GigaAmDownloader.kt
+++ b/app/src/main/java/com/antivocale/app/transcription/GigaAmDownloader.kt
@@ -1,0 +1,70 @@
+package com.antivocale.app.transcription
+
+import android.content.Context
+import com.antivocale.app.data.download.DownloadState
+import com.antivocale.app.data.download.SherpaOnnxModelConfig
+import com.antivocale.app.data.download.SherpaOnnxModelDownloader
+import java.io.File
+
+/**
+ * Downloads the GigaAM v3 model for sherpa-onnx from the govorun-lite GitHub release.
+ *
+ * The ONNX files are NOT hosted on HuggingFace; they are published as GitHub release
+ * assets at `http://github.com/amidexe/govorun-lite/releases/download/model-gigaam-v3`.
+ * A custom [SherpaOnnxModelConfig.urlBuilder] points the shared downloader at those URLs.
+ *
+ * Single-variant (like [NemotronDownloader]). Delegates to [SherpaOnnxModelDownloader].
+ */
+object GigaAmDownloader {
+
+    /**
+     * The directory name used for the GigaAM model. Read-only exposure so
+     * [GigaAmModelManager.validModelDirNames] can feed [cleanOrphanedModelDirs].
+     */
+    val modelDirName: String get() = GigaAmModelManager.GIGAAM_MODEL_DIR
+
+    /** Releases download root for the sherpa-onnx-prepackaged GigaAM v3 files. */
+    private const val RELEASE_BASE_URL =
+        "https://github.com/amidexe/govorun-lite/releases/download/model-gigaam-v3"
+
+    private val config = SherpaOnnxModelConfig(
+        tag = "GigaAmDownloader",
+        modelDirNames = mapOf(Unit to modelDirName),
+        hfFileNames = mapOf(
+            Unit to GigaAmModelManager.REQUIRED_FILES
+        ),
+        estimatedSizeMB = { GigaAmModelManager.ESTIMATED_SIZE_MB },
+        modelStorageDir = { context -> GigaAmModelManager.getModelStorageDir(context) },
+        isValidModel = { dir -> GigaAmModelManager.validateModelDirectory(dir) != null },
+        // GigaAM ships as GitHub release assets, not a HuggingFace repo (which the
+        // default downloader would otherwise hit). Build the direct asset URL.
+        urlBuilder = { _, fileName -> "$RELEASE_BASE_URL/$fileName" }
+    )
+
+    private val delegate = SherpaOnnxModelDownloader(config)
+
+    fun detectPartialDownload(context: Context): DownloadState.PartiallyDownloaded? =
+        delegate.detectPartialDownload(context, Unit)
+
+    fun clearPartialDownload(context: Context): Boolean =
+        delegate.clearPartialDownload(context, Unit)
+
+    suspend fun downloadModel(
+        context: Context,
+        onProgress: (Float) -> Unit = {},
+        onStateChange: (DownloadState) -> Unit = {}
+    ): Result<File> = delegate.downloadModel(context, Unit, onProgress, onStateChange)
+
+    fun cancel() = delegate.cancel(Unit)
+
+    fun isModelDownloaded(context: Context): Boolean =
+        delegate.isModelDownloaded(context, Unit)
+
+    fun getModelPath(context: Context): String? =
+        delegate.getModelPath(context, Unit)
+
+    fun getEstimatedSizeMB(): Long = delegate.getEstimatedSizeMB(Unit)
+
+    fun deleteModel(context: Context): Boolean =
+        delegate.deleteModel(context, Unit)
+}

--- a/app/src/main/java/com/antivocale/app/transcription/GigaAmModelManager.kt
+++ b/app/src/main/java/com/antivocale/app/transcription/GigaAmModelManager.kt
@@ -1,0 +1,172 @@
+package com.antivocale.app.transcription
+
+import android.content.Context
+import android.util.Log
+import com.antivocale.app.data.download.ResumeDownloadHelper
+import java.io.File
+
+/**
+ * Manages GigaAM v3 model discovery and validation.
+ *
+ * GigaAM v3 (Sber, MIT) is an end-to-end Russian ASR transducer converted to the
+ * sherpa-onnx format (nemo_transducer). Files:
+ * - gigaam_v3_e2e_rnnt_encoder_int8.onnx
+ * - gigaam_v3_e2e_rnnt_decoder.onnx
+ * - gigaam_v3_e2e_rnnt_joint.onnx
+ * - gigaam_v3_e2e_rnnt_tokens.txt
+ *
+ * Single-variant (like Nemotron). Mirrors [NemotronModelManager].
+ */
+object GigaAmModelManager {
+
+    private const val TAG = "GigaAmModelManager"
+
+    // Model directory name in app storage
+    const val GIGAAM_MODEL_DIR = "gigaam-v3"
+
+    // Required model files for GigaAM v3 (nemo_transducer, sherpa-onnx format).
+    val REQUIRED_FILES = listOf(
+        "gigaam_v3_e2e_rnnt_encoder_int8.onnx",
+        "gigaam_v3_e2e_rnnt_decoder.onnx",
+        "gigaam_v3_e2e_rnnt_joint.onnx",
+        "gigaam_v3_e2e_rnnt_tokens.txt"
+    )
+
+    /** Approximate total size in MB (~310MB of ONNX + tokens). */
+    const val ESTIMATED_SIZE_MB = 326L
+
+    /**
+     * The set of currently-known GigaAM variant directory names.
+     *
+     * GigaAM is single-variant, so this has exactly one entry. Used by
+     * [cleanOrphanedModelDirs] to identify stranded old-format directories.
+     */
+    val validModelDirNames: Set<String>
+        get() = setOf(GIGAAM_MODEL_DIR)
+
+    /**
+     * Gets the directory where GigaAM models are stored.
+     */
+    fun getModelStorageDir(context: Context): File {
+        return File(context.filesDir, GIGAAM_MODEL_DIR)
+    }
+
+    /**
+     * Discovers available GigaAM models in app storage.
+     *
+     * @param context Application context
+     * @return List of valid model directories (each containing all required files)
+     */
+    fun discoverModels(context: Context): List<GigaAmModel> {
+        val models = mutableListOf<GigaAmModel>()
+        val storageDir = getModelStorageDir(context)
+
+        if (!storageDir.exists()) {
+            Log.d(TAG, "Model storage directory does not exist: ${storageDir.absolutePath}")
+            return emptyList()
+        }
+
+        // Look for directories containing all required files
+        storageDir.listFiles()?.filter { it.isDirectory }?.forEach { modelDir ->
+            val model = validateModelDirectory(modelDir)
+            if (model != null) {
+                models.add(model)
+            }
+        }
+
+        Log.i(TAG, "Discovered ${models.size} GigaAM model(s)")
+        return models
+    }
+
+    /**
+     * Validates a model directory and returns a GigaAmModel if valid.
+     */
+    fun validateModelDirectory(modelDir: File): GigaAmModel? {
+        if (!modelDir.isDirectory) return null
+
+        // Single pass: validate completeness and accumulate size
+        var totalSize = 0L
+        for (requiredFile in REQUIRED_FILES) {
+            val file = File(modelDir, requiredFile)
+            val complete = if (requiresSidecarCheck(file.name))
+                ResumeDownloadHelper.isFileComplete(file)
+            else file.exists()
+            if (!complete) {
+                Log.d(TAG, "Model directory ${modelDir.name} missing/incomplete: $requiredFile")
+                return null
+            }
+            totalSize += file.length()
+        }
+
+        return GigaAmModel(
+            name = modelDir.name,
+            path = modelDir.absolutePath,
+            sizeBytes = totalSize
+        )
+    }
+
+    /**
+     * Checks if a valid GigaAM model exists at the given path.
+     */
+    fun isValidModelPath(path: String): Boolean =
+        isValidModelDir(File(path))
+
+    /**
+     * Gets model info for display purposes.
+     */
+    fun getModelInfo(modelPath: String): GigaAmModel? =
+        validateModelDirectory(File(modelPath))
+
+    /**
+     * Checks whether a directory contains all required model files.
+     */
+    private fun isValidModelDir(dir: File): Boolean {
+        if (!dir.exists() || !dir.isDirectory) return false
+        return REQUIRED_FILES.all { requiredFile ->
+            val file = File(dir, requiredFile)
+            if (requiresSidecarCheck(file.name))
+                ResumeDownloadHelper.isFileComplete(file)
+            else file.exists()
+        }
+    }
+
+    /** ONNX files are downloaded via resumable HTTP and verified via .size sidecar. */
+    private fun requiresSidecarCheck(fileName: String): Boolean =
+        fileName.endsWith(".onnx")
+
+    /**
+     * Deletes a model directory and all its contents.
+     */
+    fun deleteModel(modelPath: String): Boolean {
+        val dir = File(modelPath)
+        if (!dir.exists()) return true
+
+        return try {
+            dir.deleteRecursively()
+            Log.i(TAG, "Deleted model: $modelPath")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to delete model: $modelPath", e)
+            false
+        }
+    }
+
+    /**
+     * Gets the total size of all models in storage.
+     */
+    fun getTotalModelsSize(context: Context): Long {
+        return discoverModels(context).sumOf { it.sizeBytes }
+    }
+}
+
+/**
+ * Represents a GigaAM v3 model.
+ */
+data class GigaAmModel(
+    val name: String,
+    val path: String,
+    val sizeBytes: Long
+) {
+    val sizeFormatted: String
+        get() = com.antivocale.app.util.formatFileSize(sizeBytes)
+}

--- a/app/src/main/java/com/antivocale/app/transcription/GigaAmModelVariant.kt
+++ b/app/src/main/java/com/antivocale/app/transcription/GigaAmModelVariant.kt
@@ -1,0 +1,18 @@
+package com.antivocale.app.transcription
+
+import com.antivocale.app.R
+
+/**
+ * Single-variant descriptor for the GigaAM v3 model.
+ *
+ * GigaAM has no user-facing variant selector (the downloader is `Unit`-keyed),
+ * but the shared [com.antivocale.app.ui.components.ModelVariantCard] requires a
+ * [ModelVariant] to render. This object supplies that.
+ */
+object GigaAmModelVariant : ModelVariant {
+    override val titleResId: Int = R.string.gigaam_title
+    override val descriptionResId: Int = R.string.gigaam_description
+    override val dirName: String = GigaAmModelManager.GIGAAM_MODEL_DIR
+    override val estimatedSizeMB: Long = GigaAmModelManager.ESTIMATED_SIZE_MB
+    override val supportedLanguageCodes: Set<String> = Language.GIGAAM
+}

--- a/app/src/main/java/com/antivocale/app/transcription/Language.kt
+++ b/app/src/main/java/com/antivocale/app/transcription/Language.kt
@@ -106,6 +106,9 @@ object Language {
         "no", "sk", "sl", "et", "lv",
     )
 
+    /** GigaAM v3: Russian only (E2E RNNT, Sber). */
+    val GIGAAM: Set<String> = setOf("ru")
+
     /** Gemma models: broad multilingual (140+ languages). */
     val GEMMA: Set<String> = setOf(
         "af", "am", "ar", "as", "az", "be", "bg", "bn", "bs", "ca",

--- a/app/src/main/java/com/antivocale/app/transcription/ModelInfoProvider.kt
+++ b/app/src/main/java/com/antivocale/app/transcription/ModelInfoProvider.kt
@@ -111,6 +111,20 @@ object ModelInfoProvider {
                 performanceNotes = R.string.model_info_notes_parakeet
             ))
 
+            put("gigaam-v3", ModelInfo(
+                architectureType = ArchitectureType.TRANSDUCER,
+                maxAudioDuration = null,
+                recommendedThreads = 4..6,
+                quantizationLevel = "INT8",
+                isArm64Only = true,
+                supportsProgressiveTranscription = false,
+                vadRecommended = false,
+                benchmarkWer = null,
+                relativeSpeed = null,
+                bestFor = R.string.model_info_best_for_gigaam,
+                performanceNotes = R.string.model_info_notes_gigaam
+            ))
+
             put("gemma-4-gguf-q4km", ModelInfo(
                 architectureType = ArchitectureType.LLM,
                 maxAudioDuration = null,

--- a/app/src/main/java/com/antivocale/app/transcription/TranscriptionOrchestrator.kt
+++ b/app/src/main/java/com/antivocale/app/transcription/TranscriptionOrchestrator.kt
@@ -305,6 +305,7 @@ class TranscriptionOrchestrator @Inject constructor(
                 WhisperBackend.BACKEND_ID -> loadWhisperBackend(context)
                 Qwen3AsrBackend.BACKEND_ID -> loadQwen3AsrBackend(context)
                 NemotronStreamingBackend.BACKEND_ID -> loadNemotronBackend(context)
+                GigaAmBackend.BACKEND_ID -> loadGigaAmBackend(context)
                 "gemma4_gguf" -> loadGgufBackend(context)
                 else -> loadLlmBackend(context)
             }
@@ -431,6 +432,19 @@ class TranscriptionOrchestrator @Inject constructor(
                     else -> lang
                 }
             },
+            context = context
+        )
+    }
+
+    private suspend fun loadGigaAmBackend(context: Context): Result<Unit> {
+        val modelPath = preferencesManager.gigaamModelPath.first()
+        if (modelPath.isNullOrBlank()) {
+            return Result.failure(TranscriptionException.NotInitialized())
+        }
+        return configureSherpaBackend(
+            backendId = GigaAmBackend.BACKEND_ID,
+            modelPath = modelPath,
+            label = "GigaAM",
             context = context
         )
     }
@@ -1234,6 +1248,7 @@ class TranscriptionOrchestrator @Inject constructor(
             Qwen3AsrBackend.BACKEND_ID -> preferencesManager.qwen3AsrModelPath.first()
             SherpaOnnxBackend.BACKEND_ID -> preferencesManager.parakeetModelPath.first()
             NemotronStreamingBackend.BACKEND_ID -> preferencesManager.nemotronModelPath.first()
+            GigaAmBackend.BACKEND_ID -> preferencesManager.gigaamModelPath.first()
             "gemma4_gguf" -> preferencesManager.ggufModelPath.first()
             else -> preferencesManager.modelPath.first()
         } ?: ""

--- a/app/src/main/java/com/antivocale/app/ui/tabs/ModelTab.kt
+++ b/app/src/main/java/com/antivocale/app/ui/tabs/ModelTab.kt
@@ -46,6 +46,9 @@ import com.antivocale.app.transcription.Qwen3AsrModelManager
 import com.antivocale.app.transcription.NemotronDownloader
 import com.antivocale.app.transcription.NemotronModelVariant
 import com.antivocale.app.transcription.NemotronStreamingBackend
+import com.antivocale.app.transcription.GigaAmBackend
+import com.antivocale.app.transcription.GigaAmDownloader
+import com.antivocale.app.transcription.GigaAmModelVariant
 import com.antivocale.app.transcription.ParakeetDownloader
 import com.antivocale.app.transcription.ParakeetModelManager
 import com.antivocale.app.transcription.Language
@@ -105,6 +108,7 @@ fun ModelTab(
     val whisperState by viewModel.whisperState.collectAsState()
     val qwen3AsrState by viewModel.qwen3AsrState.collectAsState()
     val nemotronState by viewModel.nemotronState.collectAsState()
+    val gigaAmState by viewModel.gigaAmState.collectAsState()
     val ggufState by viewModel.ggufState.collectAsState()
 
     // Transcription active state — used to warn about destructive operations
@@ -148,6 +152,9 @@ fun ModelTab(
     }
     val visibleQwen3AsrVariants = remember(filterLanguageCode) {
         filterVariants(Qwen3AsrModelManager.Variant.entries, filterLanguageCode) { it.supportedLanguageCodes }
+    }
+    val showGigaAm = remember(filterLanguageCode) {
+        filterLanguageCode == null || filterLanguageCode in Language.GIGAAM
     }
     val showParakeet = remember(filterLanguageCode) {
         filterLanguageCode == null || filterLanguageCode in Language.PARAKEET
@@ -335,6 +342,28 @@ fun ModelTab(
         )
     }
 
+    // GigaAM download confirmation dialog
+    if (gigaAmState.showDownloadDialog) {
+        DownloadConfirmationDialog(
+            title = stringResource(R.string.gigaam_download_confirm_title),
+            message = stringResource(R.string.gigaam_download_confirm_message, GigaAmModelVariant.estimatedSizeMB.toInt()),
+            onConfirm = { viewModel.confirmGigaAmDownload() },
+            onDismiss = { viewModel.dismissGigaAmDownloadDialog() }
+        )
+    }
+
+    // GigaAM delete confirmation dialog
+    if (gigaAmState.showDeleteDialog) {
+        val gigaamDisplayName = stringResource(R.string.gigaam_name)
+        DeleteConfirmationDialog(
+            modelName = gigaamDisplayName,
+            isTranscribing = isTranscribing,
+            isActiveModel = uiState.modelName == gigaamDisplayName,
+            onConfirm = { viewModel.confirmGigaAmDelete() },
+            onDismiss = { viewModel.dismissGigaAmDeleteDialog() }
+        )
+    }
+
     // GGUF: disabled — download/delete dialogs commented out (GgufVariant type unavailable)
     // if (ggufState.showDownloadDialog) { ... viewModel.confirmGgufDownload() ... }
     // if (ggufState.showDeleteDialog) { ... viewModel.confirmGgufDelete() ... }
@@ -484,6 +513,16 @@ fun ModelTab(
             guardedModelSwitch = guardedSwitch,
             onInfoClick = { modelInfoVariant = NemotronModelVariant }
         )
+
+        // GigaAM v3 section - Russian ASR backend (single-variant)
+        if (showGigaAm) {
+            GigaAmDownloadSection(
+                viewModel = viewModel,
+                activeModelName = uiState.modelName,
+                guardedModelSwitch = guardedSwitch,
+                onInfoClick = { modelInfoVariant = GigaAmModelVariant }
+            )
+        }
 
         // GGUF section - on-device LLM text generation via llama.cpp
         // Hidden: llama-bro 1.2.3 does not yet support the Gemma 4 GGUF architecture.
@@ -893,6 +932,112 @@ private fun NemotronDownloadSection(
                             NemotronStreamingBackend.BACKEND_ID,
                             path,
                             context.getString(R.string.nemotron_name)
+                        )
+                    }
+                },
+                onInfoClick = { onInfoClick(variant) }
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+
+// ==================== GigaAM Download Section ====================
+
+/**
+ * Section for downloading the GigaAM v3 model (sherpa-onnx nemo_transducer backend).
+ * Single-variant — renders one [ModelVariantCard] bound to [GigaAmModelVariant].
+ */
+@Composable
+private fun GigaAmDownloadSection(
+    viewModel: ModelViewModel,
+    activeModelName: String,
+    guardedModelSwitch: (() -> Unit) -> Unit = {},
+    onInfoClick: (ModelVariant) -> Unit = {}
+) {
+    val context = LocalContext.current
+    val gigaAmState by viewModel.gigaAmState.collectAsState()
+    val variant = GigaAmModelVariant
+    val isDownloaded = gigaAmState.modelPath != null
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = when {
+                gigaAmState.isDownloading -> MaterialTheme.colorScheme.secondaryContainer
+                else -> MaterialTheme.colorScheme.surfaceVariant
+            }
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = when {
+                            isDownloaded -> Icons.Default.CheckCircle
+                            gigaAmState.isDownloading -> Icons.Default.CloudDownload
+                            else -> Icons.Default.GraphicEq
+                        },
+                        contentDescription = null,
+                        tint = when {
+                            isDownloaded -> MaterialTheme.colorScheme.primary
+                            gigaAmState.isDownloading -> MaterialTheme.colorScheme.secondary
+                            else -> MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = stringResource(R.string.gigaam_title),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = stringResource(R.string.gigaam_description),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            ModelVariantCard(
+                state = ModelVariantCardState(
+                    variant = variant,
+                    isActive = activeModelName == stringResource(R.string.gigaam_name),
+                    downloadProgress = gigaAmState.downloadProgress,
+                    downloadState = gigaAmState.downloadState,
+                    errorMessage = gigaAmState.errorMessage,
+                    partialDownload = gigaAmState.partialDownload,
+                    buttonState = when {
+                        gigaAmState.isDownloading -> DownloadButtonState.Downloading
+                        isDownloaded -> DownloadButtonState.Downloaded
+                        gigaAmState.partialDownload != null -> DownloadButtonState.PartiallyDownloaded
+                        else -> DownloadButtonState.Idle
+                    }
+                ),
+                downloadButtonTextResId = R.string.gigaam_download,
+                onDownloadClick = { viewModel.showGigaAmDownloadDialog() },
+                onCancelClick = { viewModel.cancelGigaAmDownload() },
+                onResumeClick = { viewModel.resumeGigaAmDownload() },
+                onClearPartialClick = { viewModel.clearGigaAmPartialDownload() },
+                onUseClick = { guardedModelSwitch { viewModel.useGigaAmModel() } },
+                onDeleteClick = { viewModel.showGigaAmDeleteDialog() },
+                onBenchmarkClick = {
+                    val path = GigaAmDownloader.getModelPath(context)
+                    if (path != null) {
+                        viewModel.startBenchmark(
+                            GigaAmBackend.BACKEND_ID,
+                            path,
+                            context.getString(R.string.gigaam_name)
                         )
                     }
                 },

--- a/app/src/main/java/com/antivocale/app/ui/viewmodel/ModelViewModel.kt
+++ b/app/src/main/java/com/antivocale/app/ui/viewmodel/ModelViewModel.kt
@@ -13,6 +13,9 @@ import com.antivocale.app.data.ModelDownloader
 import com.antivocale.app.data.PreferencesManager
 import com.antivocale.app.data.ShareTargetManager
 import com.antivocale.app.transcription.LlmTranscriptionBackend
+import com.antivocale.app.transcription.GigaAmBackend
+import com.antivocale.app.transcription.GigaAmDownloader
+import com.antivocale.app.transcription.GigaAmModelManager
 import com.antivocale.app.transcription.NemotronDownloader
 import com.antivocale.app.transcription.NemotronModelManager
 import com.antivocale.app.transcription.NemotronStreamingBackend
@@ -172,6 +175,21 @@ class ModelViewModel @Inject constructor(
     )
 
     /**
+     * GigaAM v3 download UI state — single-variant (GigaAmDownloader is `Unit`-keyed),
+     * so a single download slot is tracked instead of a per-variant map. Mirrors [NemotronUiState].
+     */
+    data class GigaAmUiState(
+        val isDownloading: Boolean = false,
+        val downloadProgress: Float = 0f,
+        val downloadState: DownloadState = DownloadState.Idle,
+        val modelPath: String? = null,
+        val errorMessage: String? = null,
+        val partialDownload: DownloadState.PartiallyDownloaded? = null,
+        val showDownloadDialog: Boolean = false,
+        val showDeleteDialog: Boolean = false
+    )
+
+    /**
      * GGUF download UI state — uses String-based variant keys since GGUF classes are disabled.
      * GGUF: change String back to Gemma4GgufModelManager.GgufVariant when re-enabling
      */
@@ -220,6 +238,10 @@ class ModelViewModel @Inject constructor(
     private val _nemotronState = MutableStateFlow(NemotronUiState())
     val nemotronState: StateFlow<NemotronUiState> = _nemotronState.asStateFlow()
 
+    // GigaAM state - must be declared before init block
+    private val _gigaAmState = MutableStateFlow(GigaAmUiState())
+    val gigaAmState: StateFlow<GigaAmUiState> = _gigaAmState.asStateFlow()
+
     // GGUF state - must be declared before init block
     private val _ggufState = MutableStateFlow(GgufUiState())
     val ggufState: StateFlow<GgufUiState> = _ggufState.asStateFlow()
@@ -252,6 +274,7 @@ class ModelViewModel @Inject constructor(
                     ExtractionService.ModelType.WHISPER -> handleServiceProgressWhisper(progress)
                     ExtractionService.ModelType.QWEN3_ASR -> handleServiceProgressQwen3Asr(progress)
                     ExtractionService.ModelType.NEMOTRON -> handleServiceProgressNemotron(progress)
+                    ExtractionService.ModelType.GIGAAM -> handleServiceProgressGigaAm(progress)
                     // GGUF: disabled
                     ExtractionService.ModelType.GEMMA4_GGUF -> { /* no-op */ }
                     ExtractionService.ModelType.GEMMA -> handleServiceProgressGemma(progress)
@@ -272,6 +295,8 @@ class ModelViewModel @Inject constructor(
         refreshQwen3AsrState()
         // Check for Nemotron model
         refreshNemotronState()
+        // Check for GigaAM model
+        refreshGigaAmState()
         // GGUF: disabled — refreshGgufState() commented out
         // Detect partial downloads
         detectPartialDownloads()
@@ -306,8 +331,12 @@ class ModelViewModel @Inject constructor(
                 NemotronModelManager.getModelStorageDir(context),
                 NemotronModelManager.validModelDirNames
             )
+            val gigaamReclaimed = com.antivocale.app.transcription.cleanOrphanedModelDirs(
+                GigaAmModelManager.getModelStorageDir(context),
+                GigaAmModelManager.validModelDirNames
+            )
 
-            val total = parakeetReclaimed + whisperReclaimed + qwen3Reclaimed + nemotronReclaimed
+            val total = parakeetReclaimed + whisperReclaimed + qwen3Reclaimed + nemotronReclaimed + gigaamReclaimed
             if (total > 0L) {
                 Log.i(
                     TAG,
@@ -315,7 +344,8 @@ class ModelViewModel @Inject constructor(
                         "(parakeet=${com.antivocale.app.util.formatFileSize(parakeetReclaimed)}, " +
                         "whisper=${com.antivocale.app.util.formatFileSize(whisperReclaimed)}, " +
                         "qwen3=${com.antivocale.app.util.formatFileSize(qwen3Reclaimed)}, " +
-                        "nemotron=${com.antivocale.app.util.formatFileSize(nemotronReclaimed)})"
+                        "nemotron=${com.antivocale.app.util.formatFileSize(nemotronReclaimed)}, " +
+                        "gigaam=${com.antivocale.app.util.formatFileSize(gigaamReclaimed)})"
                 )
             }
         }
@@ -585,6 +615,43 @@ class ModelViewModel @Inject constructor(
         )
     }
 
+    private fun handleServiceProgressGigaAm(progress: ExtractionService.ExtractionProgress) {
+        handleServiceProgress(
+            state = progress.downloadState,
+            updateFlow = { state, prog ->
+                _gigaAmState.update {
+                    it.copy(downloadState = state, downloadProgress = prog ?: it.downloadProgress)
+                }
+            },
+            onError = { msg, _ ->
+                _gigaAmState.update { it.copy(isDownloading = false, errorMessage = msg) }
+                detectPartialDownloads()
+            },
+            onComplete = { file ->
+                _gigaAmState.update {
+                    it.copy(
+                        modelPath = file.absolutePath,
+                        isDownloading = false,
+                        downloadProgress = 1f,
+                        downloadState = DownloadState.Idle
+                    )
+                }
+                shareTargetManager.onModelDownloaded()
+                viewModelScope.launch {
+                    preferencesManager.saveGigaAmModelPath(file.absolutePath)
+                }
+                if (_uiState.value.modelName.isBlank()) useGigaAmModel()
+                viewModelScope.launch {
+                    _snackbarEvent.tryEmit(SnackbarEvent.Message(ctx.getString(R.string.gigaam_downloaded, ctx.getString(R.string.gigaam_name))))
+                }
+            },
+            onCancelled = {
+                _gigaAmState.update { it.copy(isDownloading = false, errorMessage = null) }
+                detectPartialDownloads()
+            }
+        )
+    }
+
     private fun handleServiceProgressGemma(progress: ExtractionService.ExtractionProgress) {
         val variant = ModelDownloader.ModelVariant.entries
             .find { it.name.lowercase() == progress.variant }
@@ -813,6 +880,13 @@ class ModelViewModel @Inject constructor(
                     _nemotronState.update { it.copy(partialDownload = nemotronPartial) }
                 }
             }
+            // Check GigaAM (single-variant) — only when not actively downloading
+            if (!_gigaAmState.value.isDownloading && GigaAmDownloader.getModelPath(context) == null) {
+                val gigaamPartial = GigaAmDownloader.detectPartialDownload(context)
+                if (gigaamPartial != null) {
+                    _gigaAmState.update { it.copy(partialDownload = gigaamPartial) }
+                }
+            }
         }
     }
 
@@ -888,6 +962,22 @@ class ModelViewModel @Inject constructor(
                             modelName = modelName,
                             statusMessage = if (isValid) ctx.getString(R.string.backend_model_ready, modelName) else ctx.getString(R.string.backend_model_not_found, modelName)
                         )}
+                    }
+                }
+                GigaAmBackend.BACKEND_ID -> {
+                    // Load GigaAM model path
+                    val gigaamPath = preferencesManager.gigaamModelPath.first()
+                    if (!gigaamPath.isNullOrBlank()) {
+                        val modelDir = File(gigaamPath)
+                        val isValid = modelDir.exists() && modelDir.isDirectory
+                        val modelName = ctx.getString(R.string.gigaam_name)
+                        _uiState.update { st ->
+                            st.copy(
+                                modelPath = gigaamPath,
+                                modelName = modelName,
+                                statusMessage = if (isValid) ctx.getString(R.string.backend_model_ready, modelName) else ctx.getString(R.string.backend_model_not_found, modelName)
+                            )
+                        }
                     }
                 }
                 "gemma4_gguf" -> {
@@ -1972,6 +2062,131 @@ class ModelViewModel @Inject constructor(
         }
     }
 
+    // ==================== GigaAM Model Download ====================
+
+    /**
+     * Refreshes the GigaAM model state. Single-variant: checks whether the model
+     * is downloaded and resolves its path.
+     */
+    fun refreshGigaAmState() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val context = ctx
+            val path = GigaAmDownloader.getModelPath(context)
+            _gigaAmState.update { it.copy(modelPath = path) }
+        }
+    }
+
+    // ==================== GigaAM Confirmation Dialogs ====================
+
+    fun showGigaAmDownloadDialog() {
+        _gigaAmState.update { it.copy(showDownloadDialog = true) }
+    }
+
+    fun dismissGigaAmDownloadDialog() {
+        _gigaAmState.update { it.copy(showDownloadDialog = false) }
+    }
+
+    fun confirmGigaAmDownload() {
+        startGigaAmDownload()
+    }
+
+    fun showGigaAmDeleteDialog() {
+        _gigaAmState.update { it.copy(showDeleteDialog = true) }
+    }
+
+    fun dismissGigaAmDeleteDialog() {
+        _gigaAmState.update { it.copy(showDeleteDialog = false) }
+    }
+
+    fun confirmGigaAmDelete() {
+        _gigaAmState.update { it.copy(showDeleteDialog = false) }
+        deleteGigaAmModel()
+    }
+
+    // ==================== GigaAM Download Methods ====================
+
+    fun startGigaAmDownload() {
+        _gigaAmState.update {
+            it.copy(
+                showDownloadDialog = false,
+                isDownloading = true,
+                downloadProgress = 0f,
+                downloadState = DownloadState.Connecting(""),
+                errorMessage = null,
+                partialDownload = null
+            )
+        }
+        val context = ctx
+        val intent = Intent(context, ExtractionService::class.java).apply {
+            putExtra(ExtractionService.EXTRA_MODEL_TYPE, ExtractionService.ModelType.GIGAAM.key)
+        }
+        ContextCompat.startForegroundService(context, intent)
+    }
+
+    fun cancelGigaAmDownload() {
+        GigaAmDownloader.cancel()
+        stopExtractionService(ExtractionService.ModelType.GIGAAM, null)
+        viewModelScope.launch(Dispatchers.IO) {
+            val partial = GigaAmDownloader.detectPartialDownload(ctx)
+            _gigaAmState.update {
+                it.copy(isDownloading = false, partialDownload = partial)
+            }
+        }
+    }
+
+    fun resumeGigaAmDownload() {
+        _gigaAmState.update { it.copy(partialDownload = null) }
+        startGigaAmDownload()
+    }
+
+    fun clearGigaAmPartialDownload() {
+        viewModelScope.launch(Dispatchers.IO) {
+            GigaAmDownloader.clearPartialDownload(ctx)
+            _gigaAmState.update { it.copy(partialDownload = null) }
+        }
+    }
+
+    fun useGigaAmModel() {
+        viewModelScope.launch {
+            val context = ctx
+            val modelPath = GigaAmDownloader.getModelPath(context) ?: _gigaAmState.value.modelPath
+            if (modelPath != null) {
+                preferencesManager.saveGigaAmModelPath(modelPath)
+                preferencesManager.saveTranscriptionBackend(GigaAmBackend.BACKEND_ID)
+
+                val displayName = context.getString(R.string.gigaam_name)
+                val message = context.getString(R.string.model_selected_message, displayName)
+                _uiState.update {
+                    it.copy(
+                        modelName = displayName,
+                        status = ModelStatus.UNLOADED,
+                        statusMessage = message
+                    )
+                }
+
+                _snackbarEvent.tryEmit(SnackbarEvent.Message(message))
+                llmManager.resetKeepAliveTimer()
+            }
+        }
+    }
+
+    fun deleteGigaAmModel() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val context = ctx
+            val success = GigaAmDownloader.deleteModel(context)
+            if (success) {
+                val savedPath = preferencesManager.gigaamModelPath.first()
+                if (savedPath != null) {
+                    preferencesManager.clearGigaAmModelPath()
+                    _uiState.update { it.copy(modelPath = "", modelName = "") }
+                    shareTargetManager.onModelDeleted(GigaAmBackend.BACKEND_ID)
+                }
+                _gigaAmState.update { it.copy(modelPath = null) }
+                _snackbarEvent.tryEmit(SnackbarEvent.Message(context.getString(R.string.gigaam_deleted, context.getString(R.string.gigaam_name))))
+            }
+        }
+    }
+
     // ==================== GGUF: DISABLED ====================
     // Move files from app/src/gguf-disabled/ back to main and uncomment to re-enable
     /* GGUF disabled
@@ -2184,7 +2399,7 @@ class ModelViewModel @Inject constructor(
                         provider = resolvedProvider
                     )
                 }
-                SherpaOnnxBackend.BACKEND_ID, Qwen3AsrBackend.BACKEND_ID, NemotronStreamingBackend.BACKEND_ID -> BackendConfig.SherpaOnnxConfig(
+                SherpaOnnxBackend.BACKEND_ID, Qwen3AsrBackend.BACKEND_ID, NemotronStreamingBackend.BACKEND_ID, GigaAmBackend.BACKEND_ID -> BackendConfig.SherpaOnnxConfig(
                     modelDir = modelPath,
                     numThreads = threadCount,
                     provider = resolvedProvider

--- a/app/src/main/java/com/antivocale/app/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/antivocale/app/ui/viewmodel/SettingsViewModel.kt
@@ -23,6 +23,7 @@ import com.antivocale.app.transcription.Qwen3AsrModelManager
 // GGUF: import com.antivocale.app.transcription.Gemma4GgufBackend
 // GGUF: import com.antivocale.app.transcription.Gemma4GgufModelManager
 import com.antivocale.app.transcription.SherpaOnnxBackend
+import com.antivocale.app.transcription.GigaAmBackend
 import com.antivocale.app.transcription.NemotronStreamingBackend
 import com.antivocale.app.transcription.WhisperBackend
 import com.antivocale.app.transcription.TranscriptionBackendManager
@@ -682,6 +683,18 @@ class SettingsViewModel @Inject constructor(
                     preferencesManager.nemotronModelPath.collect { path ->
                         val modelName = if (!path.isNullOrBlank()) {
                             getApplication<Application>().getString(R.string.nemotron_name)
+                        } else null
+                        _uiState.update { it.copy(
+                            currentModelPath = path,
+                            currentModelName = modelName
+                        )}
+                    }
+                }
+                GigaAmBackend.BACKEND_ID -> {
+                    // Show GigaAM model
+                    preferencesManager.gigaamModelPath.collect { path ->
+                        val modelName = if (!path.isNullOrBlank()) {
+                            getApplication<Application>().getString(R.string.gigaam_name)
                         } else null
                         _uiState.update { it.copy(
                             currentModelPath = path,

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -145,6 +145,17 @@
     <string name="nemotron_downloaded">%1$s scaricato</string>
     <string name="nemotron_deleted">%1$s eliminato</string>
 
+    <!-- GigaAM v3 -->
+    <string name="gigaam_title">GigaAM v3</string>
+    <string name="gigaam_description">ASR russo • ~326MB • Sber (MIT)</string>
+    <string name="gigaam_name">GigaAM v3</string>
+    <string name="gigaam_download_confirm_title">Scaricare GigaAM v3?</string>
+    <string name="gigaam_download_confirm_message">Verranno scaricati ~%1$dMB. GigaAM v3 è un modello ASR solo-russo di Sber con ottima accuratezza sul russo.</string>
+    <string name="gigaam_download">Scarica GigaAM</string>
+    <string name="gigaam_delete_message">Eliminare il modello GigaAM v3?</string>
+    <string name="gigaam_downloaded">%1$s scaricato</string>
+    <string name="gigaam_deleted">%1$s eliminato</string>
+
     <!-- Download status -->
     <string name="download_status_downloading">Download in corso…</string>
     <string name="download_status_extracting">Estrazione di %1$s…</string>
@@ -664,6 +675,8 @@
     <string name="model_info_notes_qwen3">Copertura linguistica più ampia. Nota: tronca audio oltre i 30 secondi. Solo dispositivi ARM64.</string>
     <string name="model_info_best_for_parakeet">Trascrizione più veloce (17,6x più veloce di Whisper, 5,4%% WER)</string>
     <string name="model_info_notes_parakeet">Nessun limite di durata audio. VAD non necessario. Ideale per chi priorità alla velocità.</string>
+    <string name="model_info_best_for_gigaam">Migliore accuratezza sul russo on-device</string>
+    <string name="model_info_notes_gigaam">Solo russo. Punteggiatura e maiuscole native.</string>
     <string name="model_info_best_for_gemma">LLM multimodale per compiti testo + audio</string>
     <string name="model_info_notes_gemma">Non ottimizzato per ASR puro. Usare per funzionalità avanzate come comprensione audio combinata con generazione testo.</string>
     <string name="model_info_benchmark_wer">Tasso di errore parole (italiano): %.1f%%</string>
@@ -679,6 +692,7 @@
     <string name="share_target_qwen3">Anti-Vocale (Qwen3)</string>
     <string name="share_target_gemma">Anti-Vocale (Gemma)</string>
     <string name="share_target_nemotron">Anti-Vocale (Nemotron)</string>
+    <string name="share_target_gigaam">Anti-Vocale (GigaAM)</string>
     <string name="share_targets_title">Destinazioni di condivisione</string>
     <string name="share_targets_description">Mostra ogni modello scaricato come opzione separata nella scheda di condivisione di Android. Il modello viene usato temporaneamente per la singola trascrizione.</string>
     <string name="advanced_sharing_toggle">Mostra modelli nella scheda di condivisione</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,17 @@
     <string name="nemotron_downloaded">%1$s downloaded successfully</string>
     <string name="nemotron_deleted">%1$s deleted</string>
 
+    <!-- GigaAM v3 model -->
+    <string name="gigaam_title">GigaAM v3</string>
+    <string name="gigaam_description">Russian ASR • ~326MB • Sber (MIT)</string>
+    <string name="gigaam_name">GigaAM v3</string>
+    <string name="gigaam_download_confirm_title">Download GigaAM v3?</string>
+    <string name="gigaam_download_confirm_message">This will download ~%1$dMB. GigaAM v3 is a Russian-only ASR model from Sber with strong Russian accuracy.</string>
+    <string name="gigaam_download">Download GigaAM</string>
+    <string name="gigaam_delete_message">Delete GigaAM v3 model?</string>
+    <string name="gigaam_downloaded">%1$s downloaded successfully</string>
+    <string name="gigaam_deleted">%1$s deleted</string>
+
     <!-- Download status -->
     <string name="download_status_downloading">Downloading…</string>
     <string name="download_status_extracting">Extracting %1$s…</string>
@@ -738,6 +749,8 @@
     <string name="model_info_notes_qwen3">Broadest language coverage. Note: truncates audio longer than 30 seconds. ARM64 devices only.</string>
     <string name="model_info_best_for_parakeet">Fastest transcription (17.6x faster than Whisper, 5.4%% WER)</string>
     <string name="model_info_notes_parakeet">No audio length limit. VAD not needed. Best for users who prioritize speed.</string>
+    <string name="model_info_best_for_gigaam">Best Russian accuracy on-device</string>
+    <string name="model_info_notes_gigaam">Russian only. Native punctuation and capitalization.</string>
     <string name="model_info_best_for_gemma">Multimodal LLM for text + audio tasks</string>
     <string name="model_info_notes_gemma">Not optimized for pure ASR. Use for advanced features like audio understanding combined with text generation.</string>
     <string name="model_info_benchmark_wer">Word Error Rate (Italian): %.1f%%</string>
@@ -753,6 +766,7 @@
     <string name="share_target_qwen3">Anti-Vocale (Qwen3)</string>
     <string name="share_target_gemma">Anti-Vocale (Gemma)</string>
     <string name="share_target_nemotron">Anti-Vocale (Nemotron)</string>
+    <string name="share_target_gigaam">Anti-Vocale (GigaAM)</string>
 
     <!-- Advanced sharing settings -->
     <string name="share_targets_title">Share Targets</string>


### PR DESCRIPTION

## Summary

Adds **GigaAM v3**, an end-to-end Russian speech-recognition (ASR) model from **Sber**, as a new fully on-device transcription backend. It runs locally via **sherpa-onnx** (already a project dependency, **Apache-2.0**). GigaAM is the strongest on-device option for Russian, produces native punctuation and capitalization, and handles long audio in a single pass (no chunking).

---

## Reasons to modify

### New files (`app/src/main/java/com/antivocale/app/transcription/`)

| File | Purpose |
|---|---|
| `GigaAMModelVariant.kt` | Single-variant descriptor rendered by the shared `ModelVariantCard`. GigaAM has no variant selector (downloader is `Unit`-keyed), so this supplies title, description, dir name, language (`ru`), and size. |
| `GigaAmModelManager.kt` | Runtime discovery + validation: resolves the `gigaam-v3` dir, checks required ONNX files (encoder/decoder/joint) + `tokens.txt`, reusing `SherpaOnnxBackend.missingOnnxMetadata(...)` to avoid a native SIGSEGV. |
| `GigaAmDownloader.kt` | Download orchestration. **Model is NOT on Hugging Face** — fetched from the GitHub release `amidexe/govorun-lite` tag `model-gigaam-v3`: `gigaam_v3_e2e_rnnt_encoder_int8.onnx` (~305MB), `decoder.onnx`, `joint.onnx`, `tokens.txt` (~310MB total). Uses the sidecar-`.size` / `ResumeDownloadHelper.isFileComplete` integrity pattern. |
| `GigaAmBackend.kt` | The recognizer: `BACKEND_ID = "gigaam"`. GigaAM is a **nemo_transducer** model (same family as Parakeet TDT), so it reuses sherpa's `OfflineTransducerModelConfig` with GigaAM's own encoder/decoder/joint/tokens, `greedy_search`, 16 kHz. ASR-only (`supportsAudio = true`, `supportsText = false`, no chunking). |

### Modified files — every backend dispatch site

- `Language.kt` → `Language.GIGAM = setOf("ru")` (Russian-only).
- `SherpaOnnxModelDownloader.kt` → generalized for non-HF sources: new `urlBuilder: ((variant, fileName) -> String)?` on `SherpaOnnxModelConfig`, takes priority over the default HF URL when set.
- `TranscriptionOrchestrator.kt` → `loadGigaAmBackend`, `modelPathForBackend()` mapping, benchmark config.
- `ExtractionService.kt` → `ModelType.GIGAAM` enum + download/cancel/displayName dispatch.
- `TranscriptionModule.kt` (Hilt) → `provideGigaAmBackend` via `@IntoSet`.
- `PreferencesManager.kt` / `PreferencesManagerImpl.kt` → `gigaamModelPath` Flow + save/clear (key `GIGAAM_MODEL_PATH`).
- `ShareTargetManager.kt` → `.ShareGigaGigaam` share target + `hasModel`; `ShareReceiverActivity.kt` → `ALIAS_GIGAAM` + alias→backend map; `AndroidManifest.xml` → activity-alias.
- `ModelInfoProvider.kt` → `getInfo(GigaAmModelVariant)` with `best_for_gigaam` note.
- `ModelViewModel.kt` → `GigaAmUiState` + `_gigaAmState` flow, all handlers (start/cancel/resume/delete/use), loadSavedModelPath + cleanup branches, benchmark defaults.
- `SettingsViewModel.kt` → `loadCurrentModel` branch for `gigaam` (active-model display).
- `ModelTab.kt` → `GigaAmDownloadSection` composable (mirrors `NemOTronDownloadSection`), download/delete dialogs, `Language.GIGAAM` filter.
- `strings.xml` + `values-it/strings.xml` → all `gigaam_*`, `share_target_gigaam`, `model_info_best_for_gigaam` (en + it).

---

## Licenses

- **GigaAM v3 model** — **MIT** (Sber). Permissive; redistribution and local use allowed.
- **sherpa-onnx** (native inference engine) — **Apache-2.0**; already bundled, no new dependency.
- **GigaAM ONNX assets** — hosted via upstream GitHub release; weights licensed under Sber **MIT**.

---

## Review notes

- `SherpaOnnxModelDownloader` now supports a custom `urlBuilder`; verify the default HF path for other variants is unchanged.
- **Build:** `assembleFdroidDebug` compiles cleanly (only pre-existing Kotlin deprecation warnings). `playStore` flavor not built locally — requires `app/google-services.json`.
- `sherpa-onnx.aar` is a **Git-LFS** artifact not present in `origin`; must be fetched (or otherwise provided) or CI/clean builds fail.

## Build environment

- **OS:** Windows 10/11 (x86_64)
- **JDK:** Eclipse Temurin 21.0.12+8 LTS (installed via winget; project requires `jvmTarget = 21`)
- **Android SDK:** freshly provisioned at `C:\Users\DFG\Android\Sdk`
  - cmdline-tools 11076708 (`latest`)
  - platform-tools 37.0.1
  - platforms;android-36 (compileSdk = 36, minSdk = 26, targetSdk = 36)
  - build-tools 36.0.0 (35.0.0 auto-installed by AGP)
  - SDK path pinned via `local.properties` (`sdk.dir`)
- **Gradle / AGP / Kotlin:** Gradle 8.11.1 (wrapper), Android Gradle Plugin 8.10.0, Kotlin 2.2.0, Compose plugin 2.2.0, KSP 2.2.0-2.0.2, Hilt 2.56.1
- **Native dependency:** `sherpa-onnx.aar` v1.13.4 (all 4 ABIs), downloaded from the official `k2-fsa/sherpa-onnx` GitHub release — the file is Git-LFS tracked and absent from `origin`, so it must be fetched separately

Resolves https://github.com/RisorseArtificiali/anti-vocale/issues/24

<details>
  <summary>Tested on Vivo X100Pro running Android 15</summary>
<img width="452" height="960" alt="image" src="https://github.com/user-attachments/assets/8acb2a87-1e5f-4e7d-b0ad-c466a2193a4e" />
<img width="452" height="960" alt="image" src="https://github.com/user-attachments/assets/2a99eadc-8b20-44ed-be05-d70b0701061b" />
<img width="452" height="960" alt="image" src="https://github.com/user-attachments/assets/24ec9030-3fc1-4eee-b5f8-418d9baf6f2b" />
<img width="452" height="960" alt="image" src="https://github.com/user-attachments/assets/3fe18fab-3742-456e-bb82-61aea32c7d98" />



